### PR TITLE
Travis-CI: Use OpenJDK instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 jdk:
-- oraclejdk9
-- oraclejdk8
+- openjdk9
+- openjdk8
 after_success:
 - "./gradlew bintrayUpload"
 env:

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,5 +25,5 @@ description=SOCKS library for Java
 bintrayUser=dummyUser
 bintrayApiKey=dummyApiKey
 
-officialJdk=oraclejdk7
+officialJdk=openjdk8
 gitHubUrl=https\://github.com/kruton/jsocks


### PR DESCRIPTION
The new license for Oracle JDK downloads seem something worthy
of avoidance.